### PR TITLE
[feat] Tweak verbosity levels of compile error output

### DIFF
--- a/repobee_junit4/_java.py
+++ b/repobee_junit4/_java.py
@@ -60,6 +60,19 @@ def generate_classpath(*paths: pathlib.Path, classpath: str = "") -> str:
     return classpath
 
 
+def fqn_from_file(java_filepath: pathlib.Path) -> str:
+    """Extract the expected fully qualified class name for the given java file.
+
+    Args:
+        java_filepath: Path to a .java file.
+    """
+    if not java_filepath.suffix == ".java":
+        raise ValueError("{} not a path to a .java file".format(java_filepath))
+    package = extract_package(java_filepath)
+    simple_name = java_filepath.name[:-len(java_filepath.suffix)]
+    return fqn(package, simple_name)
+
+
 def extract_package(class_: pathlib.Path) -> str:
     """Return the name package of the class. An empty string
     denotes the default package.

--- a/repobee_junit4/_junit4_runner.py
+++ b/repobee_junit4/_junit4_runner.py
@@ -12,6 +12,7 @@ import daiquiri
 from repobee_plug import Status
 
 from repobee_junit4 import _java
+from repobee_junit4 import _output
 
 
 LOGGER = daiquiri.getLogger(__file__)
@@ -88,7 +89,7 @@ def run_test_class(
     prod_class: pathlib.Path,
     classpath: str,
     security_policy: Optional[pathlib.Path] = None,
-) -> subprocess.CompletedProcess:
+) -> _output.TestResult:
     """Run a single test class on a single production class.
 
     Args:
@@ -126,4 +127,4 @@ def run_test_class(
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    return proc
+    return _output.TestResult(test_class=test_class, proc=proc)

--- a/repobee_junit4/_junit4_runner.py
+++ b/repobee_junit4/_junit4_runner.py
@@ -66,29 +66,6 @@ def _generate_default_security_policy(classpath: str) -> str:
     return _DEFAULT_SECURITY_POLICY_TEMPLATE.format(junit4_jar_path=path)
 
 
-def get_num_failed(test_output: bytes) -> int:
-    """Get the amount of failed tests from the error output of JUnit4."""
-    decoded = test_output.decode(encoding=sys.getdefaultencoding())
-    match = re.search(r"Failures: (\d+)", decoded)
-    # TODO this is a bit unsafe, what if there is no match?
-    return int(match.group(1))
-
-
-def get_num_passed(test_output: bytes) -> int:
-    """Get the amount of passed tests from the output of JUnit4."""
-    decoded = test_output.decode(encoding=sys.getdefaultencoding())
-    match = re.search(r"OK \((\d+) tests\)", decoded)
-    return int(match.group(1))
-
-
-def parse_failed_tests(test_output: bytes) -> str:
-    """Return a list of test failure descriptions, excluding stack traces."""
-    decoded = test_output.decode(encoding=sys.getdefaultencoding())
-    return re.findall(
-        r"^\d\) .*(?:\n(?!\s+at).*)*", decoded, flags=re.MULTILINE
-    )
-
-
 def _extract_conforming_package(test_class, prod_class):
     """Extract a package name from the test and production class.
     Raise if the test class and production class have different package
@@ -110,28 +87,23 @@ def run_test_class(
     test_class: pathlib.Path,
     prod_class: pathlib.Path,
     classpath: str,
-    verbose: bool = False,
     security_policy: Optional[pathlib.Path] = None,
-) -> Tuple[str, str]:
+) -> subprocess.CompletedProcess:
     """Run a single test class on a single production class.
 
     Args:
         test_class: Path to a Java test class.
         prod_class: Path to a Java production class.
         classpath: A classpath to use in the tests.
-        verbose: Whether to output more failure information.
     Returns:
-        ()
+        The completed process.
     """
     package = _extract_conforming_package(test_class, prod_class)
 
     prod_class_dir = _java.extract_package_root(prod_class, package)
     test_class_dir = _java.extract_package_root(test_class, package)
 
-    test_class_name = test_class.name[
-        : -len(test_class.suffix)
-    ]  # remove .java
-    test_class_name = _java.fqn(package, test_class_name)
+    test_class_name = _java.fqn_from_file(test_class)
 
     classpath = _java.generate_classpath(
         test_class_dir, prod_class_dir, classpath=classpath
@@ -154,25 +126,4 @@ def run_test_class(
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    return _extract_results(proc, test_class_name, verbose)
-
-
-def _extract_results(
-    proc: subprocess.CompletedProcess, test_class_name: str, verbose: bool
-) -> Tuple[str, str]:
-    """Extract and format results from a completed test run."""
-    if proc.returncode != 0:
-        status = Status.ERROR
-        msg = "Test class {} failed {} tests".format(
-            test_class_name, get_num_failed(proc.stdout)
-        )
-        if verbose:
-            msg += os.linesep + os.linesep.join(
-                parse_failed_tests(proc.stdout)
-            )
-    else:
-        msg = "Test class {} passed all {} tests!".format(
-            test_class_name, get_num_passed(proc.stdout)
-        )
-        status = Status.SUCCESS
-    return status, msg
+    return proc

--- a/repobee_junit4/_junit4_runner.py
+++ b/repobee_junit4/_junit4_runner.py
@@ -74,6 +74,13 @@ def get_num_failed(test_output: bytes) -> int:
     return int(match.group(1))
 
 
+def get_num_passed(test_output: bytes) -> int:
+    """Get the amount of passed tests from the output of JUnit4."""
+    decoded = test_output.decode(encoding=sys.getdefaultencoding())
+    match = re.search(r"OK \((\d+) tests\)", decoded)
+    return int(match.group(1))
+
+
 def parse_failed_tests(test_output: bytes) -> str:
     """Return a list of test failure descriptions, excluding stack traces."""
     decoded = test_output.decode(encoding=sys.getdefaultencoding())
@@ -164,6 +171,8 @@ def _extract_results(
                 parse_failed_tests(proc.stdout)
             )
     else:
-        msg = "Test class {} passed!".format(test_class_name)
+        msg = "Test class {} passed all {} tests!".format(
+            test_class_name, get_num_passed(proc.stdout)
+        )
         status = Status.SUCCESS
     return status, msg

--- a/repobee_junit4/_output.py
+++ b/repobee_junit4/_output.py
@@ -20,7 +20,7 @@ SUCCESS_COLOR = bg("dark_green")
 FAILURE_COLOR = bg("yellow")
 
 DEFAULT_LINE_LENGTH_LIMIT = 150
-DEFAULT_MAX_LINES = 5
+DEFAULT_MAX_LINES = 10
 
 
 class TestResult(

--- a/repobee_junit4/_output.py
+++ b/repobee_junit4/_output.py
@@ -21,7 +21,7 @@ from colored import bg, style
 
 
 SUCCESS_COLOR = bg("dark_green")
-FAILURE_COLOR = bg("red")
+FAILURE_COLOR = bg("yellow")
 
 
 class TestResult(
@@ -53,7 +53,7 @@ class TestResult(
 
     def pretty_result(self, verbose: bool) -> str:
         """Format this test as a pretty-printed message."""
-        title_color = bg("dark_green") if self.success else bg("red")
+        title_color = SUCCESS_COLOR if self.success else FAILURE_COLOR
         num_passed = self.num_passed
         num_failed = self.num_failed
         msg = test_result_header(

--- a/repobee_junit4/_output.py
+++ b/repobee_junit4/_output.py
@@ -1,0 +1,62 @@
+"""Utility methods for processing and formatting output.
+
+.. module:: _output
+    :synopsis: Plugin that tries to compile all .java files in a repo.
+
+.. moduleauthor:: Simon Larsén
+"""
+import sys
+import os
+import re
+import subprocess
+import collections
+
+from typing import Tuple
+
+from repobee_plug import Status
+
+TestResult = collections.namedtuple("TestResult", "")
+
+
+def get_num_failed(test_output: bytes) -> int:
+    """Get the amount of failed tests from the error output of JUnit4."""
+    decoded = test_output.decode(encoding=sys.getdefaultencoding())
+    match = re.search(r"Failures: (\d+)", decoded)
+    # TODO this is a bit unsafe, what if there is no match?
+    return int(match.group(1))
+
+
+def get_num_passed(test_output: bytes) -> int:
+    """Get the amount of passed tests from the output of JUnit4."""
+    decoded = test_output.decode(encoding=sys.getdefaultencoding())
+    match = re.search(r"OK \((\d+) tests\)", decoded)
+    return int(match.group(1))
+
+
+def parse_failed_tests(test_output: bytes) -> str:
+    """Return a list of test failure descriptions, excluding stack traces."""
+    decoded = test_output.decode(encoding=sys.getdefaultencoding())
+    return re.findall(
+        r"^\d\) .*(?:\n(?!\s+at).*)*", decoded, flags=re.MULTILINE
+    )
+
+
+def extract_results(
+    proc: subprocess.CompletedProcess, test_class: str, verbose: bool
+) -> Tuple[str, str]:
+    """Extract and format results from a completed test run."""
+    if proc.returncode != 0:
+        status = Status.ERROR
+        msg = "Test class {} failed {} tests".format(
+            test_class, get_num_failed(proc.stdout)
+        )
+        if verbose:
+            msg += os.linesep + os.linesep.join(
+                parse_failed_tests(proc.stdout)
+            )
+    else:
+        msg = "Test class {} passed all {} tests!".format(
+            test_class, get_num_passed(proc.stdout)
+        )
+        status = Status.SUCCESS
+    return status, msg

--- a/repobee_junit4/junit4.py
+++ b/repobee_junit4/junit4.py
@@ -96,7 +96,7 @@ class JUnit4Hooks(plug.Plugin):
 
             msg = self._format_results(test_results, compile_failed)
 
-            status = Status.ERROR if has_failures else Status.SUCCESS
+            status = Status.ERROR if compile_failed else (Status.WARNING if has_failures else Status.SUCCESS)
             return plug.HookResult(SECTION, status, msg)
         except _exception.ActError as exc:
             return exc.hook_result
@@ -332,7 +332,12 @@ class JUnit4Hooks(plug.Plugin):
             for res in test_results
         ]
 
-        msg = os.linesep.join([msg if self._very_verbose else _truncate_lines(msg) for msg in compile_error_messages + test_messages])
+        msg = os.linesep.join(
+            [
+                msg if self._very_verbose else _truncate_lines(msg)
+                for msg in compile_error_messages + test_messages
+            ]
+        )
         if test_messages:
             num_passed = sum([res.num_passed for res in test_results])
             num_failed = sum([res.num_failed for res in test_results])

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -243,6 +243,34 @@ Expected: is <false>
 2) oneIsNotPrime(PrimeCheckerTest)
 java.lang.AssertionError: 
 Expected: is <false>
+     but: was <true>"""[
+            : _output.DEFAULT_MAX_LINES
+        ]  # noqa: W291
+
+        result = hooks.act_on_cloned_repo(FAIL_REPO)
+
+        assert (
+            _output.test_result_header(
+                "PrimeCheckerTest",
+                NUM_PRIME_CHECKER_TESTS,
+                NUM_PRIME_CHECKER_TESTS - 2,
+                _output.FAILURE_COLOR,
+            )
+            in result.msg
+        )
+        assert expected_verbose_msg in result.msg
+
+    def test_fail_repo_very_verbose(self):
+        """Test verbose output on repo that fails tests."""
+        hooks = setup_hooks(very_verbose=True)
+
+        expected_verbose_msg = """1) isPrimeFalseForComposites(PrimeCheckerTest)
+java.lang.AssertionError: 
+Expected: is <false>
+     but: was <true>
+2) oneIsNotPrime(PrimeCheckerTest)
+java.lang.AssertionError: 
+Expected: is <false>
      but: was <true>"""  # noqa: W291
 
         result = hooks.act_on_cloned_repo(FAIL_REPO)
@@ -410,8 +438,8 @@ Expected: is <false>
         hooks = setup_hooks(verbose=True)
         line_length = 20
         monkeypatch.setattr(
-            "repobee_junit4.junit4._truncate_lines",
-            partial(junit4._truncate_lines, max_len=line_length),
+            "repobee_junit4._output._truncate_lines",
+            partial(_output._truncate_lines, max_len=line_length),
         )
 
         result = hooks.act_on_cloned_repo(FAIL_REPO)
@@ -429,8 +457,8 @@ Expected: is <false>
         hooks = setup_hooks(very_verbose=True)
         line_length = 20
         monkeypatch.setattr(
-            "repobee_junit4.junit4._truncate_lines",
-            partial(junit4._truncate_lines, max_len=line_length),
+            "repobee_junit4._output._truncate_lines",
+            partial(_output._truncate_lines, max_len=line_length),
         )
 
         result = hooks.act_on_cloned_repo(FAIL_REPO)

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -23,6 +23,7 @@ import pytest
 from repobee_plug import Status
 from repobee_plug import exception
 from repobee_junit4 import junit4
+from repobee_junit4 import _output
 
 import envvars
 
@@ -192,7 +193,7 @@ class TestActOnClonedRepo:
 
         assert result.status == Status.SUCCESS
         assert (
-            junit4.success_message("PrimeCheckerTest", NUM_PRIME_CHECKER_TESTS)
+            _output.success_message("PrimeCheckerTest", NUM_PRIME_CHECKER_TESTS)
             in result.msg
         )
 
@@ -201,7 +202,7 @@ class TestActOnClonedRepo:
         result = default_hooks.act_on_cloned_repo(SUCCESS_REPO)
 
         assert result.status == Status.SUCCESS
-        assert junit4.success_message("FiboTest", NUM_FIBO_TESTS) in result.msg
+        assert _output.success_message("FiboTest", NUM_FIBO_TESTS) in result.msg
 
     def test_fail_repo(self, default_hooks):
         """Test with repo that should have test failures."""
@@ -301,7 +302,7 @@ Expected: is <false>
 
         assert result.status == Status.SUCCESS
         assert (
-            junit4.success_message("se.repobee.fibo.FiboTest", NUM_FIBO_TESTS)
+            _output.success_message("se.repobee.fibo.FiboTest", NUM_FIBO_TESTS)
             in result.msg
         )
 
@@ -445,7 +446,4 @@ class TestSecurityPolicy:
         result = hooks.act_on_cloned_repo(UNAUTHORIZED_READ_FILE_REPO)
 
         assert result.status == Status.SUCCESS
-        assert (
-                junit4.success_message("FiboTest", NUM_FIBO_TESTS)
-            in result.msg
-        )
+        assert _output.success_message("FiboTest", NUM_FIBO_TESTS) in result.msg

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -144,7 +144,7 @@ class TestActOnClonedRepo:
 
         result = hooks.act_on_cloned_repo(BAD_TESTS_REPO)
 
-        assert result.status == Status.ERROR
+        assert result.status == Status.WARNING
         assert "Student wrote a bad test" in str(result.msg)
 
     def test_handles_duplicate_student_tests(self):
@@ -221,7 +221,7 @@ class TestActOnClonedRepo:
         """Test with repo that should have test failures."""
         result = default_hooks.act_on_cloned_repo(FAIL_REPO)
 
-        assert result.status == Status.ERROR
+        assert result.status == Status.WARNING
         assert (
             _output.test_result_header(
                 "PrimeCheckerTest",
@@ -415,7 +415,6 @@ Expected: is <false>
         )
 
         result = hooks.act_on_cloned_repo(FAIL_REPO)
-        print(result.msg)
 
         lines = result.msg.split(os.linesep)[1:]  # skip summary line
         assert len(lines) > 1
@@ -456,7 +455,7 @@ class TestSecurityPolicy:
 
         result = hooks.act_on_cloned_repo(UNAUTHORIZED_READ_FILE_REPO)
 
-        assert result.status == Status.ERROR
+        assert result.status == Status.WARNING
         assert (
             "java.security.AccessControlException: access denied" in result.msg
         )
@@ -467,7 +466,7 @@ class TestSecurityPolicy:
 
         result = hooks.act_on_cloned_repo(UNAUTHORIZED_NETWORK_ACCESS_REPO)
 
-        assert result.status == Status.ERROR
+        assert result.status == Status.WARNING
         assert (
             "java.security.AccessControlException: access denied" in result.msg
         )

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -193,7 +193,12 @@ class TestActOnClonedRepo:
 
         assert result.status == Status.SUCCESS
         assert (
-            _output.success_message("PrimeCheckerTest", NUM_PRIME_CHECKER_TESTS)
+            _output.test_result_header(
+                "PrimeCheckerTest",
+                NUM_PRIME_CHECKER_TESTS,
+                NUM_PRIME_CHECKER_TESTS,
+                _output.SUCCESS_COLOR,
+            )
             in result.msg
         )
 
@@ -202,14 +207,30 @@ class TestActOnClonedRepo:
         result = default_hooks.act_on_cloned_repo(SUCCESS_REPO)
 
         assert result.status == Status.SUCCESS
-        assert _output.success_message("FiboTest", NUM_FIBO_TESTS) in result.msg
+        assert (
+            _output.test_result_header(
+                "FiboTest",
+                NUM_FIBO_TESTS,
+                NUM_FIBO_TESTS,
+                _output.SUCCESS_COLOR,
+            )
+            in result.msg
+        )
 
     def test_fail_repo(self, default_hooks):
         """Test with repo that should have test failures."""
         result = default_hooks.act_on_cloned_repo(FAIL_REPO)
 
         assert result.status == Status.ERROR
-        assert "Test class PrimeCheckerTest failed 2 tests" in result.msg
+        assert (
+            _output.test_result_header(
+                "PrimeCheckerTest",
+                NUM_PRIME_CHECKER_TESTS,
+                NUM_PRIME_CHECKER_TESTS - 2,
+                _output.FAILURE_COLOR,
+            )
+            in result.msg
+        )
 
     def test_fail_repo_verbose(self):
         """Test verbose output on repo that fails tests."""
@@ -226,7 +247,15 @@ Expected: is <false>
 
         result = hooks.act_on_cloned_repo(FAIL_REPO)
 
-        assert "Test class PrimeCheckerTest failed 2 tests" in result.msg
+        assert (
+            _output.test_result_header(
+                "PrimeCheckerTest",
+                NUM_PRIME_CHECKER_TESTS,
+                NUM_PRIME_CHECKER_TESTS - 2,
+                _output.FAILURE_COLOR,
+            )
+            in result.msg
+        )
         assert expected_verbose_msg in result.msg
 
     def test_reference_test_dir_has_no_subdir_for_repo(self, default_hooks):
@@ -302,7 +331,12 @@ Expected: is <false>
 
         assert result.status == Status.SUCCESS
         assert (
-            _output.success_message("se.repobee.fibo.FiboTest", NUM_FIBO_TESTS)
+            _output.test_result_header(
+                "se.repobee.fibo.FiboTest",
+                NUM_FIBO_TESTS,
+                NUM_FIBO_TESTS,
+                _output.SUCCESS_COLOR,
+            )
             in result.msg
         )
 
@@ -381,8 +415,9 @@ Expected: is <false>
         )
 
         result = hooks.act_on_cloned_repo(FAIL_REPO)
+        print(result.msg)
 
-        lines = result.msg.split(os.linesep)
+        lines = result.msg.split(os.linesep)[1:]  # skip summary line
         assert len(lines) > 1
         # the first line can be somewhat longer due to staus message
         # and color codes
@@ -446,4 +481,12 @@ class TestSecurityPolicy:
         result = hooks.act_on_cloned_repo(UNAUTHORIZED_READ_FILE_REPO)
 
         assert result.status == Status.SUCCESS
-        assert _output.success_message("FiboTest", NUM_FIBO_TESTS) in result.msg
+        assert (
+            _output.test_result_header(
+                "FiboTest",
+                NUM_FIBO_TESTS,
+                NUM_FIBO_TESTS,
+                _output.SUCCESS_COLOR,
+            )
+            in result.msg
+        )

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -95,6 +95,9 @@ CLASSPATH = "some-stuf:nice/path:path/to/unimportant/lib.jar"
 
 CLASSPATH_WITH_JARS = CLASSPATH + ":{}:{}".format(JUNIT_PATH, HAMCREST_PATH)
 
+NUM_PRIME_CHECKER_TESTS = 3
+NUM_FIBO_TESTS = 2
+
 
 def setup_hooks(
     reference_tests_dir=RTD,
@@ -188,14 +191,22 @@ class TestActOnClonedRepo:
         result = default_hooks.act_on_cloned_repo(ABSTRACT_TEST_REPO)
 
         assert result.status == Status.SUCCESS
-        assert "Test class PrimeCheckerTest passed!" in result.msg
+        assert (
+            "Test class PrimeCheckerTest passed all {} tests!".format(
+                NUM_PRIME_CHECKER_TESTS
+            )
+            in result.msg
+        )
 
     def test_correct_repo(self, default_hooks):
         """Test with repo that should not have test failures."""
         result = default_hooks.act_on_cloned_repo(SUCCESS_REPO)
 
         assert result.status == Status.SUCCESS
-        assert "Test class FiboTest passed!" in result.msg
+        assert (
+            "Test class FiboTest passed all {} tests!".format(NUM_FIBO_TESTS)
+            in result.msg
+        )
 
     def test_fail_repo(self, default_hooks):
         """Test with repo that should have test failures."""
@@ -294,7 +305,11 @@ Expected: is <false>
         result = default_hooks.act_on_cloned_repo(PACKAGED_CODE_REPO)
 
         assert result.status == Status.SUCCESS
-        assert "Test class se.repobee.fibo.FiboTest passed!" in str(result.msg)
+        assert "Test class se.repobee.fibo.FiboTest passed all {} tests!".format(
+            NUM_FIBO_TESTS
+        ) in str(
+            result.msg
+        )
 
     def test_error_when_student_code_is_incorrectly_packaged(
         self, default_hooks
@@ -436,4 +451,4 @@ class TestSecurityPolicy:
         result = hooks.act_on_cloned_repo(UNAUTHORIZED_READ_FILE_REPO)
 
         assert result.status == Status.SUCCESS
-        assert "Test class FiboTest passed!" in result.msg
+        assert "Test class FiboTest passed all {} tests!".format(NUM_FIBO_TESTS) in result.msg

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -192,9 +192,7 @@ class TestActOnClonedRepo:
 
         assert result.status == Status.SUCCESS
         assert (
-            "Test class PrimeCheckerTest passed all {} tests!".format(
-                NUM_PRIME_CHECKER_TESTS
-            )
+            junit4.success_message("PrimeCheckerTest", NUM_PRIME_CHECKER_TESTS)
             in result.msg
         )
 
@@ -203,10 +201,7 @@ class TestActOnClonedRepo:
         result = default_hooks.act_on_cloned_repo(SUCCESS_REPO)
 
         assert result.status == Status.SUCCESS
-        assert (
-            "Test class FiboTest passed all {} tests!".format(NUM_FIBO_TESTS)
-            in result.msg
-        )
+        assert junit4.success_message("FiboTest", NUM_FIBO_TESTS) in result.msg
 
     def test_fail_repo(self, default_hooks):
         """Test with repo that should have test failures."""
@@ -305,10 +300,9 @@ Expected: is <false>
         result = default_hooks.act_on_cloned_repo(PACKAGED_CODE_REPO)
 
         assert result.status == Status.SUCCESS
-        assert "Test class se.repobee.fibo.FiboTest passed all {} tests!".format(
-            NUM_FIBO_TESTS
-        ) in str(
-            result.msg
+        assert (
+            junit4.success_message("se.repobee.fibo.FiboTest", NUM_FIBO_TESTS)
+            in result.msg
         )
 
     def test_error_when_student_code_is_incorrectly_packaged(
@@ -451,4 +445,7 @@ class TestSecurityPolicy:
         result = hooks.act_on_cloned_repo(UNAUTHORIZED_READ_FILE_REPO)
 
         assert result.status == Status.SUCCESS
-        assert "Test class FiboTest passed all {} tests!".format(NUM_FIBO_TESTS) in result.msg
+        assert (
+                junit4.success_message("FiboTest", NUM_FIBO_TESTS)
+            in result.msg
+        )


### PR DESCRIPTION
The amount of lines in compile errors are now truncated to a single line in normal output mode, default of 10 lines in verbose output and no truncation in very verbose mode.

Fix #64 