### PR TITLE
[fix] Add -enableassertions flag to java command

### DIFF
--- a/repobee_junit4/_junit4_runner.py
+++ b/repobee_junit4/_junit4_runner.py
@@ -110,7 +110,7 @@ def run_test_class(
         test_class_dir, prod_class_dir, classpath=classpath
     )
 
-    command = ["java"]
+    command = ["java", "-enableassertions"]
     if security_policy:
         command += [
             "-Djava.security.manager",


### PR DESCRIPTION
Without the `-enableassertions|-ea` flag, plain Java assertions are disabled, which does not make sense for testing.

Fix #65 