### PR TITLE
[fix] Make generate-rtd preserve relative directory structure

### DIFF
--- a/repobee_junit4/_generate_rtd.py
+++ b/repobee_junit4/_generate_rtd.py
@@ -150,7 +150,9 @@ def _copy_test_classes(
 ) -> Iterable[pathlib.Path]:
     reference_test_classes = src_dir.rglob("*Test.java")
     for test_class in reference_test_classes:
-        shutil.copy(src=test_class, dst=dst_dir / test_class.name)
+        dst = dst_dir / test_class.relative_to(src_dir)
+        dst.parent.mkdir(exist_ok=True, parents=True)
+        shutil.copy(src=test_class, dst=dst)
         yield test_class.relative_to(src_dir)
 
 

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/README.md
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/README.md
@@ -1,0 +1,3 @@
+This template repo contains multiple, independent test classes in different
+directories. It was initially created to assess the bug reported in
+https://github.com/repobee/repobee-junit4/issue/86

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/README.md
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/README.md
@@ -1,0 +1,1 @@
+This repo should pass all tests

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/fibo/Fibo.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/fibo/Fibo.java
@@ -1,0 +1,20 @@
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        // TODO constructor
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        // TODO implement method
+        return 0;
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/primes/AbstractPrimeCheckerTest.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/primes/AbstractPrimeCheckerTest.java
@@ -1,0 +1,32 @@
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public abstract class AbstractPrimeCheckerTest {
+    @Test
+    public void oneIsNotPrime() {
+        // but the naive prime checker thinks it is, this should fail
+        assertThat(PrimeChecker.isPrime(1), is(false));
+    }
+
+    @Test
+    public void isPrimeTrueForPrimes() {
+        int[] primes = {3, 5, 7, 97, 131, 197, 541};
+
+        for (int prime : primes) {
+            assertThat(PrimeChecker.isPrime(prime), is(true));
+        }
+    }
+
+    @Test
+    public void isPrimeFalseForComposites() {
+        int[] composites = {4, 6, 9, 25, 105, 437, 529};
+
+        for (int composite : composites) {
+            assertThat(PrimeChecker.isPrime(composite), is(false));
+        }
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/primes/PrimeChecker.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/primes/PrimeChecker.java
@@ -1,0 +1,12 @@
+/**
+ * A naive prime checker.
+ */
+
+public class PrimeChecker {
+    /**
+     * Check if a positive number n is prime.
+     */
+    public static boolean isPrime(int n) {
+        return false;
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/primes/PrimeCheckerTest.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/master_branch/src/primes/PrimeCheckerTest.java
@@ -1,0 +1,8 @@
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class PrimeCheckerTest extends AbstractPrimeCheckerTest {}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/README.md
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/README.md
@@ -1,0 +1,1 @@
+This repo should pass all tests

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/fibo/Fibo.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/fibo/Fibo.java
@@ -1,0 +1,23 @@
+/**
+ * Class for calculating Fibonacci numbers.
+ */
+
+public class Fibo {
+    private long prev;
+    private long current;
+
+    public Fibo() {
+        prev = 0;
+        current = 1;
+    }
+
+    /**
+     * Generate the next Fibonacci number.
+     */
+    public long next() {
+        long ret = prev;
+        prev = current;
+        current = ret + current;
+        return ret;
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/fibo/FiboTest.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/fibo/FiboTest.java
@@ -1,0 +1,33 @@
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class FiboTest {
+    @Test
+    public void correctlyGeneratesFirst10Numbers() {
+        Fibo f = new Fibo();
+        long[] expected = {0, 1, 1, 2, 3, 5, 8, 13, 21, 34};
+        long[] actual = new long[10];
+
+        for (int i = 0; i < 10; i++) {
+            actual[i] = f.next();
+        }
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void correctlyGeneratesFiftiethNumber() {
+        // note that the first number is counted as the 0th
+        Fibo f = new Fibo();
+
+        for (int i = 0; i < 50; i++) {
+            f.next();
+        }
+
+        assertThat(f.next(), equalTo(12586269025l));
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/primes/AbstractPrimeCheckerTest.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/primes/AbstractPrimeCheckerTest.java
@@ -1,0 +1,32 @@
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public abstract class AbstractPrimeCheckerTest {
+    @Test
+    public void oneIsNotPrime() {
+        // but the naive prime checker thinks it is, this should fail
+        assertThat(PrimeChecker.isPrime(1), is(false));
+    }
+
+    @Test
+    public void isPrimeTrueForPrimes() {
+        int[] primes = {3, 5, 7, 97, 131, 197, 541};
+
+        for (int prime : primes) {
+            assertThat(PrimeChecker.isPrime(prime), is(true));
+        }
+    }
+
+    @Test
+    public void isPrimeFalseForComposites() {
+        int[] composites = {4, 6, 9, 25, 105, 437, 529};
+
+        for (int composite : composites) {
+            assertThat(PrimeChecker.isPrime(composite), is(false));
+        }
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/primes/PrimeChecker.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/primes/PrimeChecker.java
@@ -1,0 +1,23 @@
+/**
+ * A naive prime checker.
+ */
+
+public class PrimeChecker {
+    /**
+     * Check if a positive number n is prime.
+     */
+    public static boolean isPrime(int n) {
+        if (n <= 2) {
+            return n == 2;
+        } else if (n % 2 == 0) {
+            return false;
+        }
+
+        for (int i = 3; i <= Math.sqrt(n); i += 2) {
+            if (n % i == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/primes/PrimeCheckerTest.java
+++ b/tests/fakeapi_integration_tests/template_repos/multiple-independent-tests-task/solutions_branch/src/primes/PrimeCheckerTest.java
@@ -1,0 +1,8 @@
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+public class PrimeCheckerTest extends AbstractPrimeCheckerTest {}

--- a/tests/fakeapi_integration_tests/test_with_fakeapi.py
+++ b/tests/fakeapi_integration_tests/test_with_fakeapi.py
@@ -46,7 +46,7 @@ class TestGenerateRTD:
             assignment_tests_dir = rtd_path / assignment_name
             test_files = {
                 f.relative_to(assignment_tests_dir)
-                for f in assignment_tests_dir.rglob("*")
+                for f in assignment_tests_dir.rglob("*.java")
             }
             assert test_files == EXPECTED_REFERENCE_TESTS[assignment_name]
 
@@ -151,7 +151,7 @@ ASSIGNMENT_NAMES = [
 ASSIGNMENTS_ARG = " ".join(ASSIGNMENT_NAMES)
 EXPECTED_REFERENCE_TESTS = {
     repo_dir.root.name: {
-        test_file.relative_to(repo_dir.solutions_branch / "src")
+        test_file.relative_to(repo_dir.solutions_branch)
         for test_file in repo_dir.solutions_branch.rglob("*Test.java")
     }
     for repo_dir in TEMPLATE_REPO_DIRS


### PR DESCRIPTION
Fix #86 

This PR fixes the issue explained in #86 by preserving relative directory structure. So, if for example we have a template repository `task-1` with a test at `src/FiboTest.java`, then the reference tests directory will get that test at `RTD/task-1/src/FiboTest.java`. Previously, it would end up at `RTD/task-1/FiboTest.java`, which caused issues if there were multiple independent tests in different directories in the same template repo.