### PR TITLE
[feat] Allow any version of JUnit4 to be used

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,5 +10,5 @@ fi
 
 pip install -e ".[TEST]"
 
-curl -L https://search.maven.org/remotecontent?filepath=junit/junit/4.12/junit-4.12.jar -o junit-4.12.jar
+curl -L https://search.maven.org/remotecontent?filepath=junit/junit/4.13.1/junit-4.13.1.jar -o junit-4.13.1.jar
 curl -L https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar -o hamcrest-core-1.3.jar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `repobee-junit4`, a JUnit 4.12 test runner plugin for [RepoBee](https://github.com/repobee/repobee)
+# `repobee-junit4`, a JUnit4 test runner plugin for [RepoBee](https://github.com/repobee/repobee)
 
 [![Build Status](https://travis-ci.com/repobee/repobee-junit4.svg?branch=master)](https://travis-ci.com/repobee/repobee-junit4)
 [![Code Coverage](https://codecov.io/gh/repobee/repobee-junit4/branch/master/graph/badge.svg)](https://codecov.io/gh/repobee/repobee-junit4)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ Requirements
 
    1. RepoBee installed
    2. A JDK (preferably 8+, 7 may work) installed
-   3. ``junit-4.12.jar`` and ``hamcest-core-1.3.jar`` downloaded
+   3. ``junit-4.13.1.jar`` and ``hamcest-core-1.3.jar`` downloaded
 
 First of all, make sure that RepoBee is installed and up-to-date. For a
 first-time install of RepoBee, see the `RepoBee install docs`_.
@@ -29,7 +29,7 @@ jars. They can be downloaded from Maven Central.
 
 .. code-block:: bash
 
-    curl https://search.maven.org/remotecontent?filepath=junit/junit/4.12/junit-4.12.jar -o junit-4.12.jar
+    curl https://search.maven.org/remotecontent?filepath=junit/junit/4.13.1/junit-4.13.1.jar -o junit-4.13.1.jar
     curl https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar -o hamcrest-core-1.3.jar
 
 If you don't have ``curl`` installed, just copy the links above and download
@@ -58,14 +58,14 @@ Configuration
 Some options for ``repobee-junit4`` can be configured in the `RepoBee
 configuration file`_ by adding the ``[junit4]`` section. Everything
 ``repobee-junit4`` needs to operate *can* be provided on the command line, but
-we strongly recommend adding the absolute paths to the ``junit-4.12.jar`` and
+we strongly recommend adding the absolute paths to the ``junit-4.13.1.jar`` and
 ``hamcrest-core-1.3.jar`` files to the config file. Simply append the following
 to the end of the configuration file. Here's a sample configuration.
 
 .. code-block:: bash
 
    [junit4]
-   junit4_junit_path = /absolute/path/to/junit-4.12.jar
+   junit4_junit_path = /absolute/path/to/junit-4.13.1.jar
    junit4_hamcrest_path = /absolute/path/to/hamcrest-core-1.3.jar
    junit4_reference_tests_dir = /absolute/path/to/reference_tests_dir
    junit4_timeout = 5

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -15,7 +15,7 @@ the Java SecurityManager_. The policy used looks like this:
    grant {
    };
 
-   // the `junit-4.12.jar` needs this permission for introspection
+   // the JUnit4 jar needs this permission for introspection
    grant codeBase "file:{junit4_jar_path}" {{
        permission java.lang.RuntimePermission "accessDeclaredMembers";
    }};
@@ -23,8 +23,8 @@ the Java SecurityManager_. The policy used looks like this:
 This policy disallows student code from doing most illicit things, such as
 accessing files outside of the codebases's directory, or accessing the network.
 The ``{junit4_jar_path}`` is dynamically resolved during runtime, and will lend
-the actual ``junit-4.12.jar`` archive that is used to run the test classes
-sufficient permissions to do so.
+the actual JUnit4 jar archive that is used to run the test classes sufficient
+permissions to do so.
 
 This policy seems to work well for introductory courses in Java, but there may
 be snags because of how restrictive it is. If you find that some permission

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,7 +37,8 @@ command.
       ``reference_tests_dir`` option.
     - **Required** unless specified in the configuration file.
 * ``--junit4-junit-path``
-    - Path to the ``junit-4.12.jar`` library.
+    - Path to the JUnit4 library (any version of it, but we recommend
+      ``>4.13.1``).
     - Picked up automatically if on the ``CLASSPATH`` environment variable.
     - Can be specified in the configuration file with the
       ``junit_path`` option.

--- a/repobee_junit4/_junit4_runner.py
+++ b/repobee_junit4/_junit4_runner.py
@@ -14,8 +14,8 @@ from repobee_junit4 import _output
 
 
 LOGGER = daiquiri.getLogger(__file__)
-HAMCREST_JAR = "hamcrest-core-1.3.jar"
-JUNIT_JAR = "junit-4.12.jar"
+HAMCREST_JAR_PATTERN = fr"([^{os.pathsep}]*hamcrest-core-1.3.jar)"
+JUNIT4_JAR_PATTERN = fr"([^{os.pathsep}]*junit-4\.\d+\.(\d+\.)?jar)"
 
 _DEFAULT_SECURITY_POLICY_TEMPLATE = """grant {{
 }};
@@ -54,13 +54,9 @@ def _generate_default_security_policy(classpath: str) -> str:
     """Generate the default security policy from the classpath. ``junit-4.12.jar``
     must be on the classpath.
     """
-    escaped_junit_jar = JUNIT_JAR.replace(".", r"\.")
-    pattern = "[^{sep}]*{junit_jar}".format(
-        sep=os.pathsep, junit_jar=escaped_junit_jar
-    )
-    junit_jar_matches = re.search(pattern, classpath)
+    junit_jar_matches = re.search(JUNIT4_JAR_PATTERN, classpath)
     if not junit_jar_matches:
-        raise ValueError("{} not on the classpath".format(JUNIT_JAR))
+        raise ValueError("junit4 jar not on the classpath")
     path = junit_jar_matches.group(0)
     return _DEFAULT_SECURITY_POLICY_TEMPLATE.format(junit4_jar_path=path)
 

--- a/repobee_junit4/_junit4_runner.py
+++ b/repobee_junit4/_junit4_runner.py
@@ -51,8 +51,8 @@ def security_policy(classpath: str, active: bool):
 
 
 def _generate_default_security_policy(classpath: str) -> str:
-    """Generate the default security policy from the classpath. ``junit-4.12.jar``
-    must be on the classpath.
+    """Generate the default security policy from the classpath. JUnit4 jar must
+    be on the classpath.
     """
     junit_jar_matches = re.search(JUNIT4_JAR_PATTERN, classpath)
     if not junit_jar_matches:

--- a/repobee_junit4/junit4.py
+++ b/repobee_junit4/junit4.py
@@ -4,7 +4,7 @@ classes.
 .. important::
 
     Requires ``javac`` and ``java`` to be installed, and having
-    ``hamcrest-core-1.3.jar`` and ``junit-4.12.jar`` on the local macine.
+    ``hamcrest-core-1.3.jar`` and ``junit-4.13.1.jar`` on the local macine.
 
 This plugin performs a fairly complicated tasks of running test classes from
 pre-specified reference tests on production classes that are dynamically

--- a/repobee_junit4/junit4.py
+++ b/repobee_junit4/junit4.py
@@ -19,7 +19,7 @@ discovered in student repositories. See the README for more details.
 import os
 import pathlib
 import re
-from typing import Tuple, List, Union
+from typing import Tuple, List
 
 
 import daiquiri
@@ -313,7 +313,7 @@ class JUnit4Hooks(plug.Plugin, plug.cli.CommandExtension):
 
 
 def _parse_from_classpath(
-    pattern: Union[str, re.Pattern], classpath: str = CLASSPATH
+    pattern: str, classpath: str = CLASSPATH
 ) -> pathlib.Path:
     matches = re.search(pattern, classpath).groups()
     if not matches:

--- a/repobee_junit4/junit4.py
+++ b/repobee_junit4/junit4.py
@@ -299,10 +299,10 @@ class JUnit4Hooks(plug.Plugin, plug.cli.CommandExtension):
     def _check_jars_exist(self):
         """Check that the specified jar files actually exist."""
         junit_path = self.junit4_junit_path or _parse_from_classpath(
-            _junit4_runner.JUNIT4_JAR_PATTERN
+            _junit4_runner.JUNIT4_JAR_PATTERN, CLASSPATH
         )
         hamcrest_path = self.junit4_hamcrest_path or _parse_from_classpath(
-            _junit4_runner.HAMCREST_JAR_PATTERN
+            _junit4_runner.HAMCREST_JAR_PATTERN, CLASSPATH
         )
         for raw_path in (junit_path, hamcrest_path):
             if not pathlib.Path(raw_path).is_file():
@@ -312,12 +312,10 @@ class JUnit4Hooks(plug.Plugin, plug.cli.CommandExtension):
                 )
 
 
-def _parse_from_classpath(
-    pattern: str, classpath: str = CLASSPATH
-) -> pathlib.Path:
-    matches = re.search(pattern, classpath).groups()
+def _parse_from_classpath(pattern: str, classpath: str) -> pathlib.Path:
+    matches = re.search(pattern, classpath)
     if not matches:
         raise plug.PlugError(
             f"expected to find match for '{pattern}' on the CLASSPATH variable"
         )
-    return matches[0] if matches else None
+    return matches.group(0) if matches else None

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ required = ["repobee>=3.3.0", "daiquiri", "colored"]
 setup(
     name="repobee-junit4",
     version=__version__,
-    description="JUnit-4.12 plugin for repobee",
+    description="JUnit4 runner plugin for RepoBee",
     long_description=readme,
     long_description_content_type="text/markdown",
     author="Simon Larsén",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,15 @@
-from repobee_junit4._junit4_runner import HAMCREST_JAR, JUNIT_JAR
-
+from repobee_junit4 import _junit4_runner
 from envvars import JUNIT_PATH, HAMCREST_PATH
+import re
 
-if JUNIT_PATH.name != JUNIT_JAR:
+if not re.search(_junit4_runner.JUNIT4_JAR_PATTERN, str(JUNIT_PATH)):
     raise RuntimeError(
         "test suite requires the env variable "
-        "REPOBEE_JUNIT4_JUNIT to contain the path to `{}`".format(JUNIT_JAR)
+        "REPOBEE_JUNIT4_JUNIT to contain the path to the junit4 jar"
     )
 
-if HAMCREST_PATH.name != HAMCREST_JAR:
+if not re.search(_junit4_runner.HAMCREST_JAR_PATTERN, str(HAMCREST_PATH)):
     raise RuntimeError(
         "test suite requires the env variable "
-        "REPOBEE_JUNIT4_HAMCREST to contain the path to `{}`".format(
-            HAMCREST_JAR
-        )
+        "REPOBEE_JUNIT4_HAMCREST to contain the path to the hamcrest library"
     )

--- a/tests/export_vars.sh
+++ b/tests/export_vars.sh
@@ -1,5 +1,5 @@
 # this script exports the paths to junit and hamcrest on MY machine
 # change the paths to what is appropriate for yours
 
-export REPOBEE_JUNIT4_JUNIT='/usr/share/java/junit/junit-4.12.jar'
+export REPOBEE_JUNIT4_JUNIT='/usr/share/java/junit/junit-4.13.1.jar'
 export REPOBEE_JUNIT4_HAMCREST='/usr/share/java/junit/hamcrest-core-1.3.jar'

--- a/tests/integration_tests/test_end_to_end.py
+++ b/tests/integration_tests/test_end_to_end.py
@@ -7,7 +7,7 @@
         1. ``javac`` must be installed.
         2. A path to ``hamcrest-core-1.3.jar`` must be in the environment
         variable REPOBEE_JUNIT4_HAMCREST.
-        3. A path to ``junit-4.12.jar`` must be in the environment variable
+        3. A path to a JUnit4 jar must be in the environment variable
         REPOBEE_JUNIT4_JUNIT.
 """
 import pathlib


### PR DESCRIPTION
Fix #79 

Now, any version of JUnit4 can be used. We recommend 4.13.1 or later.