### PR TITLE
[docs] Improve generate-rtd usage docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -210,7 +210,6 @@ trick.
    $ repobee -p junit4 \
         junit4 generate-rtd \
         --assignments fibonacci \
-        --students ham spam eggs \
         --reference-tests-dir /path/to/reference_tests \
         --branch solutions \
         --template-org-name course-template-repos

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -200,25 +200,33 @@ repositories on the ``master`` branch, and the full solutions on a branch called
 
 Given that the reference tests are present on a branch in a template repo, the
 ``junit4 generate-rtd`` command can be used to extract test classes from it.
-Execute it like so.
+Assuming that the reference tests are on the ``solutions`` branch of the
+``fibonacci`` template repo, the following command should do the
+trick.
 
 .. code-block:: bash
 
-   $ repobee -p junit4 generate-rtd -a fibonacci -s ham spam eggs --reference-tests-dir /path/to/reference_tests --branch solutions
+   $ repobee -p junit4 \
+        junit4 generate-rtd \
+        --assignments fibonacci \
+        --students ham spam eggs \
+        --reference-tests-dir /path/to/reference_tests \
+        --branch solutions
 
-Assuming ``FiboTest.java`` was present on the ``solutions``` branch, a
-test directory called ``fibonacci`` should have been generated in the
-reference tests directory:
+Assuming ``FiboTest.java`` was present on the ``solutions``` branch, a test
+directory called ``fibonacci`` should have been generated in the reference
+tests directory:
 
 .. code-block:: bash
 
    reference_tests
    └── fibonacci
-       └── FiboTest.java
+       └── src
+           └── FiboTest.java
 
 To later generate test directories for other assignments, simply run the
-command again but with other assignments (i.e. other arguments for the ``-a``
-option).
+command again but with other assignments (i.e. other arguments for the
+``--assignments`` option).
 
 .. important::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -201,7 +201,8 @@ repositories on the ``master`` branch, and the full solutions on a branch called
 Given that the reference tests are present on a branch in a template repo, the
 ``junit4 generate-rtd`` command can be used to extract test classes from it.
 Assuming that the reference tests are on the ``solutions`` branch of the
-``fibonacci`` template repo, the following command should do the
+``fibonacci`` template repo, and the template itself is located in the
+organization ``course-template-repos``, the following command should do the
 trick.
 
 .. code-block:: bash
@@ -211,7 +212,8 @@ trick.
         --assignments fibonacci \
         --students ham spam eggs \
         --reference-tests-dir /path/to/reference_tests \
-        --branch solutions
+        --branch solutions \
+        --template-org-name course-template-repos
 
 Assuming ``FiboTest.java`` was present on the ``solutions``` branch, a test
 directory called ``fibonacci`` should have been generated in the reference

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -214,6 +214,11 @@ trick.
         --branch solutions \
         --template-org-name course-template-repos
 
+.. note::
+
+    If you haven't configured RepoBee for your targeted platform, the command
+    may ask for additional options.
+
 Assuming ``FiboTest.java`` was present on the ``solutions``` branch, a test
 directory called ``fibonacci`` should have been generated in the reference
 tests directory:


### PR DESCRIPTION
Fix #97 

They had some errors and weren't too clear about some things, such as `--template-org-name`.