### PR TITLE
[break] Rename rtd option in generate-rtd to make it configurable

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -210,7 +210,7 @@ trick.
    $ repobee -p junit4 \
         junit4 generate-rtd \
         --assignments fibonacci \
-        --reference-tests-dir /path/to/reference_tests \
+        --junit4-reference-tests-dir /path/to/reference_tests \
         --branch solutions \
         --template-org-name course-template-repos
 

--- a/repobee_junit4/_generate_rtd.py
+++ b/repobee_junit4/_generate_rtd.py
@@ -42,10 +42,11 @@ class GenerateRTD(plug.Plugin, plug.cli.Command):
         ],
     )
 
-    reference_tests_dir = plug.cli.option(
+    junit4_reference_tests_dir = plug.cli.option(
         help="path to place the root reference tets directory at",
         converter=pathlib.Path,
         required=True,
+        configurable=True,
     )
     branch = plug.cli.option(
         help="the branch to search for reference tests in each template "
@@ -55,7 +56,7 @@ class GenerateRTD(plug.Plugin, plug.cli.Command):
 
     def command(self, api: plug.PlatformAPI):
         existing_test_dirs = _get_existing_assignment_test_dirs(
-            self.reference_tests_dir, self.args.assignments
+            self.junit4_reference_tests_dir, self.args.assignments
         )
         if existing_test_dirs:
             return plug.Result(
@@ -73,7 +74,7 @@ class GenerateRTD(plug.Plugin, plug.cli.Command):
             assignment_names_progress,
             branch=self.branch,
             template_org_name=self.args.template_org_name,
-            reference_tests_dir=self.reference_tests_dir,
+            reference_tests_dir=self.junit4_reference_tests_dir,
             api=api,
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colored
 daiquiri
-repobee>=3.3.0
+repobee>=3.3.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = [
     "pytest-mock",
     "pytest>=4.0.0",
 ]
-required = ["repobee>=3.3.0", "daiquiri", "colored"]
+required = ["repobee>=3.3.1", "daiquiri", "colored"]
 
 setup(
     name="repobee-junit4",

--- a/tests/fakeapi_integration_tests/test_with_fakeapi.py
+++ b/tests/fakeapi_integration_tests/test_with_fakeapi.py
@@ -181,7 +181,7 @@ def run_generate_rtd(
         f"--template-org-name "
         f"{repobee_testhelpers.const.TEMPLATE_ORG_NAME} "
         f"--branch {branch} "
-        f"--reference-tests-dir {rtd}",
+        f"--junit4-reference-tests-dir {rtd}",
         plugins=[junit4],
         workdir=workdir,
     )[str(_generate_rtd.JUNIT4_COMMAND_CATEGORY.generate_rtd)][0]


### PR DESCRIPTION
Fix #96 

This PR renames the `generate-rtd --reference-tests-dir` option to `--junit4-reference-tests-dir` to make it configurable. Now it picks up on the `junit4_reference_tests_dir` option in the config file.